### PR TITLE
Bug Content-Type sous JBoss

### DIFF
--- a/vertigo-vega-impl/src/main/java/io/vertigo/vega/plugins/webservice/handler/converter/DefaultJsonSerializer.java
+++ b/vertigo-vega-impl/src/main/java/io/vertigo/vega/plugins/webservice/handler/converter/DefaultJsonSerializer.java
@@ -75,7 +75,7 @@ public final class DefaultJsonSerializer implements JsonSerializer {
 		/** Type JSON simple */
 		JSON(""),
 		/** Type JSON UiContext */
-		JSON_UI_CONTEXT("json+uicontext"),
+		JSON_UI_CONTEXT("json+uicontext="),
 		/** Type JSON list */
 		JSON_LIST("json+list=%s"),
 		/** Type JSON entity */


### PR DESCRIPTION
Suite à l’erreur RDD I-CARE j’ai repéré le bug suivant dans Vertigo vega 0.9.4 (mais toujours présent dans la branche master).

Symptôme :

La récupération de la réponse d’un webservice avec le webclient d’apache CXF lançait l’exception suivante :

javax.ws.rs.ProcessingException: java.lang.IllegalArgumentException: Wrong media type parameter, separator is missing
                at org.apache.cxf.jaxrs.client.WebClient.handleResponse(WebClient.java:1145)
                at org.apache.cxf.jaxrs.client.WebClient.doResponse(WebClient.java:1114)
                at org.apache.cxf.jaxrs.client.WebClient.doChainedInvocation(WebClient.java:1039)
                at org.apache.cxf.jaxrs.client.WebClient.doInvoke(WebClient.java:894)
                at org.apache.cxf.jaxrs.client.WebClient.doInvoke(WebClient.java:862)
                at org.apache.cxf.jaxrs.client.WebClient.invoke(WebClient.java:427)
                at org.apache.cxf.jaxrs.client.WebClient.get(WebClient.java:607)
                at rdd_icare.a_rdd_individu_pivot_0_1.a_rdd_individu_pivot.tFileInputDelimited_1Process(a_rdd_individu_pivot.java:8093)
                at rdd_icare.a_rdd_individu_pivot_0_1.a_rdd_individu_pivot.tFileExist_1Process(a_rdd_individu_pivot.java:1150)
                at rdd_icare.a_rdd_individu_pivot_0_1.a_rdd_individu_pivot.tPostgresqlConnection_1Process(a_rdd_individu_pivot.java:949)
                at rdd_icare.a_rdd_individu_pivot_0_1.a_rdd_individu_pivot.runJobInTOS(a_rdd_individu_pivot.java:13135)
                at rdd_icare.a_rdd_individu_pivot_0_1.a_rdd_individu_pivot.runJob(a_rdd_individu_pivot.java:12868)
                at rdd_icare.rdd_main_job_0_1.rdd_main_job.tRunJob_1Process(rdd_main_job.java:1748)
                at rdd_icare.rdd_main_job_0_1.rdd_main_job.tJava_11Process(rdd_main_job.java:1486)
                at rdd_icare.rdd_main_job_0_1.rdd_main_job.tRunJob_10Process(rdd_main_job.java:1317)
                at rdd_icare.rdd_main_job_0_1.rdd_main_job.tJava_1Process(rdd_main_job.java:991)
                at rdd_icare.rdd_main_job_0_1.rdd_main_job.runJobInTOS(rdd_main_job.java:6528)
                at rdd_icare.rdd_main_job_0_1.rdd_main_job.main(rdd_main_job.java:6253)
Caused by: java.lang.IllegalArgumentException: Wrong media type parameter, separator is missing
                at org.apache.cxf.jaxrs.impl.MediaTypeHeaderProvider.addParameter(MediaTypeHeaderProvider.java:121)
                at org.apache.cxf.jaxrs.impl.MediaTypeHeaderProvider.internalValueOf(MediaTypeHeaderProvider.java:108)
                at org.apache.cxf.jaxrs.impl.MediaTypeHeaderProvider.valueOf(MediaTypeHeaderProvider.java:65)
                at org.apache.cxf.jaxrs.utils.JAXRSUtils.toMediaType(JAXRSUtils.java:1739)
                at org.apache.cxf.jaxrs.impl.ResponseImpl.getMediaType(ResponseImpl.java:257)
                at org.apache.cxf.jaxrs.impl.ResponseImpl.doReadEntity(ResponseImpl.java:341)
                at org.apache.cxf.jaxrs.client.AbstractClient.readBody(AbstractClient.java:528)
                at org.apache.cxf.jaxrs.client.WebClient.handleResponse(WebClient.java:1126)
                ... 17 more

Le problème se produit lorsque la webapp est servie par un serveur JBoss. Il provient du Content-Type qui a la forme « application/json;json+uicontext;charset=UTF-8 ». Ici le json+uicontext est invalide car il y manque le signe ‘=’. Il devrait être le suivant : « Content-Type: application/json;json+uicontext=;charset=UTF-8 » pour respecter le format des « parameters » de ce champ http. 
La valeur de ce champs est géré par l’enum JSON_UI_CONTEXT de la classe io.vertigo.vega.plugins.webservice.handler.converter.DefaultJsonSerializer.

Dans le cas d’un déployement sous tomcat, le problème ne se pose pas car le serveur « corrige » ce champs en ajoutant le signe.